### PR TITLE
Cache parsed properties, change provided properties to fields

### DIFF
--- a/src/CssClassesTypeProvider.fs
+++ b/src/CssClassesTypeProvider.fs
@@ -75,23 +75,18 @@ module TypeProvider =
       let getProperties = args.[ 3 ] :?> bool
       let nameCollisions = args.[ 4 ] :?> NameCollisions
 
-      let parseSampleToTypeSpec _ value =
-        using ( logTimeType typeName this.Id "ParseAndGenerateMembers" typeName ) <| fun _ ->
-
-        let cssType = ProvidedTypeDefinition( asm , ns , typeName , Some ( typeof< obj > ) )
+      let tryParseText value =
         logType typeName this.Id "Parsing CSS"
-        let cssClasses = Utils.parseCss value naming nameCollisions
-        logType typeName this.Id "Adding type members"
-        Utils.addTypeMembersFromCss getProperties cssClasses cssType
+        Utils.parseCss value naming nameCollisions
 
-        {
-          GeneratedType = cssType
-          RepresentationType = cssType
-          WasValidInput = Option.isSome cssClasses
-        }
+      let createType parseResult =
+        logType typeName this.Id "Creating type"
+        let cssType = ProvidedTypeDefinition( asm , ns , typeName , Some ( typeof< obj > ) )
+        Utils.addTypeMembersFromCss getProperties parseResult cssType
+        cssType
 
       let source = args.[ 0 ] |> processStringParameter
-      generateType source parseSampleToTypeSpec commandConfig this config finalResolutionFolder typeName
+      generateType source commandConfig this config finalResolutionFolder typeName tryParseText createType
 
     let parameters = [
       ProvidedStaticParameter( "source" , typeof< string >, parameterDefaultValue = "" )

--- a/src/TypedCssClasses.fsproj
+++ b/src/TypedCssClasses.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
     <Configurations>Debug;Release;ReleaseTest</Configurations>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Zanaptak.TypedCssClasses</PackageId>
     <Authors>zanaptak</Authors>

--- a/test/TypedCssClasses.Tests/Tests.fs
+++ b/test/TypedCssClasses.Tests/Tests.fs
@@ -3,6 +3,7 @@ module TypedCssClasses.Tests
 open NUnit.Framework
 open Zanaptak.TypedCssClasses
 open Zanaptak.TypedCssClasses.Utils
+open Zanaptak.TypedCssClasses.Internal.FSharpData.ProvidedTypes
 open System
 open System.Reflection
 open System.IO


### PR DESCRIPTION
Introduce longer cache for file and process parsed results in addition to the shorter generated type cache.

Also change the provided type to use public literal fields instead of properties. This improves the performance of large IDE completion lists.

Below are informal timings on large sets of Tailwind CSS classes, from the moment of typing a dot on the type until the unfiltered completion list appearing, also compared to a module of hard-coded literals. Time in seconds on a desktop i7-4790k CPU.

| Source | Tailwind classes | Visual Studio 2019 | Visual Studio Code |
| - | - | - | - |
| TypedCssClasses 0.3.1 | 13851 | 2.1 | 3.3 |
| TypedCssClasses 0.4.0 | 13851 | 1.2 | 2.2 |
| hard-coded module | 13851 | 0.7 | 1.7 |
| TypedCssClasses 0.3.1 | 5535 | 1.1 | 1.8 |
| TypedCssClasses 0.4.0 | 5535 | 0.7 | 1.3 |
| hard-coded module | 5535 | 0.4 | 1.2 |

Note: The lower Tailwind class count obtained by configuring 1 responsive screen breakpoint instead of the default of 4. See [Tailwind CSS theme configuration](https://tailwindcss.com/docs/theme/#screens).

Fixes #7.