### PR TITLE
Support CSS modules

### DIFF
--- a/src/CssClassesTypeProvider.fs
+++ b/src/CssClassesTypeProvider.fs
@@ -79,14 +79,15 @@ module TypeProvider =
         logType typeName this.Id "Parsing CSS"
         Utils.parseCss value naming nameCollisions
 
-      let createType parseResult =
+      let createType isCssModule source parseResult =
         logType typeName this.Id "Creating type"
         let cssType = ProvidedTypeDefinition( asm , ns , typeName , Some ( typeof< obj > ) )
-        Utils.addTypeMembersFromCss getProperties parseResult cssType
+        Utils.addTypeMembersFromCss isCssModule source getProperties parseResult cssType
         cssType
 
       let source = args.[ 0 ] |> processStringParameter
-      generateType source commandConfig this config finalResolutionFolder typeName tryParseText createType
+      let isCssModule = source.StartsWith(".") && source.EndsWith(".module.css")
+      generateType source commandConfig this config finalResolutionFolder typeName tryParseText (createType isCssModule source)
 
     let parameters = [
       ProvidedStaticParameter( "source" , typeof< string >, parameterDefaultValue = "" )

--- a/src/CssClassesTypeProvider.fs
+++ b/src/CssClassesTypeProvider.fs
@@ -71,23 +71,23 @@ module TypeProvider =
       logfType typeName this.Id "Configured resolution folder: %s" finalResolutionFolder
       logfType typeName this.Id "Configured command: %s" commandParam
 
+      let source = args.[ 0 ] |> processStringParameter
       let naming = args.[ 1 ] :?> Naming
       let getProperties = args.[ 3 ] :?> bool
       let nameCollisions = args.[ 4 ] :?> NameCollisions
+      let fableCssModule = args.[ 11 ] :?> bool
 
       let tryParseText value =
         logType typeName this.Id "Parsing CSS"
         Utils.parseCss value naming nameCollisions
 
-      let createType isCssModule source parseResult =
+      let createType parseResult =
         logType typeName this.Id "Creating type"
         let cssType = ProvidedTypeDefinition( asm , ns , typeName , Some ( typeof< obj > ) )
-        Utils.addTypeMembersFromCss isCssModule source getProperties parseResult cssType
+        Utils.addTypeMembersFromCss fableCssModule source getProperties parseResult cssType
         cssType
 
-      let source = args.[ 0 ] |> processStringParameter
-      let isCssModule = source.StartsWith(".") && source.EndsWith(".module.css")
-      generateType source commandConfig this config finalResolutionFolder typeName tryParseText (createType isCssModule source)
+      generateType source commandConfig this config finalResolutionFolder typeName tryParseText createType
 
     let parameters = [
       ProvidedStaticParameter( "source" , typeof< string >, parameterDefaultValue = "" )
@@ -101,6 +101,7 @@ module TypeProvider =
       ProvidedStaticParameter( "argumentSuffix" , typeof< string >, parameterDefaultValue = "" )
       ProvidedStaticParameter( "osDelimiters" , typeof< string >, parameterDefaultValue = ",=" )
       ProvidedStaticParameter( "expandVariables" , typeof< bool >, parameterDefaultValue = true )
+      ProvidedStaticParameter( "fableCssModule" , typeof< bool >, parameterDefaultValue = false )
     ]
 
     let helpText = """
@@ -119,6 +120,7 @@ module TypeProvider =
       <param name='osDelimiters'>Characters that separate platform-specific values in the provided parameters.
         Default is ",="</param>
       <param name='expandVariables'>Expand environment variables in the provided parameters.</param>
+      <param name='fableCssModule'>Resolve properties to Fable import expressions instead of raw class names to allow processing as a CSS Module.</param>
     """
 
     do parentType.AddXmlDoc helpText

--- a/src/Fable.Core.fs
+++ b/src/Fable.Core.fs
@@ -3,4 +3,5 @@
 
 module Fable.Core.JsInterop
 
-let import<'T> (selector: string) (path: string): 'T = failwith "js native"
+let import<'T> (selector: string) (path: string): 'T =
+    failwithf "Attempted to use Fable CSS Module import expression in non-Fable context (class:%s, source:%s) [Zanaptak.TypedCssClasses]" selector path

--- a/src/Fable.Core.fs
+++ b/src/Fable.Core.fs
@@ -1,0 +1,6 @@
+// Fable replaces methods from Fable.Core just by fullname so we can avoid
+// reference issues by including the methods we need in this assembly
+
+module Fable.Core.JsInterop
+
+let import<'T> (selector: string) (path: string): 'T = failwith "js native"

--- a/src/TypedCssClasses.fsproj
+++ b/src/TypedCssClasses.fsproj
@@ -48,6 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Fable.Core.fs" />
     <Compile Include="Types.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="CssClassesTypeProvider.fs" />

--- a/src/Utils.fs
+++ b/src/Utils.fs
@@ -5,6 +5,7 @@ open System.Globalization
 open System.Text.RegularExpressions
 open System.Collections.Generic
 open System.Runtime.InteropServices
+open System.Web
 open Zanaptak.TypedCssClasses.Internal.ProviderImplementation.ProvidedTypes
 open Zanaptak.TypedCssClasses.Internal.FSharpData.ProvidedTypes
 open Zanaptak.TypedCssClasses.Internal.FSharpData.Helpers
@@ -460,7 +461,7 @@ let importClassFromCssModule (source: string) (className: string) =
     // import style from "./style.module.css";
     // let myClass = style.["my-class"];
     let selector = Expr.Value("default." + className)
-    let path = Expr.Value(source)
+    let path = Expr.Value(HttpUtility.JavaScriptStringEncode source)
     fun (_args: Expr list) -> <@@ Fable.Core.JsInterop.import<string> %%selector %%path @@>
 
 let addTypeMembersFromCss isCssModule source getProperties ( cssClasses : Property array ) ( cssType : ProvidedTypeDefinition ) =


### PR DESCRIPTION
Add support for CSS modules in combination with bundlers like Webpack. When using a relative path that ends with ".module.css", instead of erasing to strings the class properties will turn into Fable import expressions. These imports will be used by Webpack that will recognize the CSS module (because of the ".module.css" suffix) and mangle the class names as can be seen in the image below, achieving the effect of locally-scoped CSS.

![image](https://user-images.githubusercontent.com/8275461/123520459-c4106700-d6eb-11eb-9538-c3e388c02e1a.png)

> Cons: This is Fable-specific so the function will only be available in Fable projects.